### PR TITLE
Patch to support discid_read_sparse

### DIFF
--- a/CoverArt.cc
+++ b/CoverArt.cc
@@ -195,7 +195,7 @@ boolean CCoverArt::FillInputBuffer(j_decompress_ptr cinfo)
 	src->pub.next_input_byte = src->eoi_buffer;
 	src->pub.bytes_in_buffer = 2;
 
-	return true;
+	return (boolean)true;
 }
 
 void CCoverArt::SkipInputData(j_decompress_ptr cinfo, long num_bytes)

--- a/DiscIDWrapper.cc
+++ b/DiscIDWrapper.cc
@@ -40,7 +40,11 @@ CDiscIDWrapper::~CDiscIDWrapper()
 
 bool CDiscIDWrapper::FromDevice(const std::string& Device)
 {
+#if defined(DISCID_VERSION_MAJOR) && (DISCID_VERSION_MAJOR > 0 || (DISCID_VERSION_MAJOR == 0 && DISCID_VERSION_MINOR >= 4))
+	return discid_read_sparse(m_DiscID,Device.c_str(),DISCID_FEATURE_READ);
+#else
 	return discid_read(m_DiscID,Device.c_str());
+#endif
 }
 
 bool CDiscIDWrapper::FromCuesheet(const CCuesheet& Cuesheet)


### PR DESCRIPTION
Author: Sebastian Ramacher, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=736445

> In version 0.5.0 of libdiscid discid_read_sparce got added. This
> function allows to specify what should be read from the disc. Using this
> function one can avoid reading of the MCN of the disc and ISRCs from the
> tracks. Only the disc ID is used and nothing else, so it is not
> necessary to read the other information.
> 
> Please consider applying the attached patch.
> 